### PR TITLE
🚔🔥🚗💥🚌 prevent name collisions

### DIFF
--- a/emoji/emoji_transfer_service.py
+++ b/emoji/emoji_transfer_service.py
@@ -1,11 +1,19 @@
 from emoji import image_client
 
-def transfer(source_client, destination_client, emoji_name):
+def collision_free_name(destination_dict, emoji_name, prefix="cav"):
+    existing_name = destination_dict.get(emoji_name)
+
+    if existing_name is not None:
+        return "{}-{}".format(prefix, emoji_name)
+
+    return emoji_name
+
+def transfer(source_client, destination_client, source_emoji_name):
     source_dict = source_client.emoji_dict()
     destination_dict = destination_client.emoji_dict()
 
-    emoji_path = source_dict.get(emoji_name)
-
+    emoji_path = source_dict.get(source_emoji_name)
+    # deciding what call to make
     if emoji_path.startswith("alias:"):
         """If it's an alias, we want to get the url for the file"""
         aliased_from = emoji_path.replace("alias:", "")
@@ -13,8 +21,11 @@ def transfer(source_client, destination_client, emoji_name):
 
     if emoji_path is None:
         """Making an alias for a standard emoji"""
-        return destination_client.add_alias(emoji_name, aliased_from)
+        return destination_client.add_alias(source_emoji_name, aliased_from)
+    else:
+        destination_emoji_name = collision_free_name(destination_dict, source_emoji_name)
+        print("adding {}".format(destination_emoji_name))
+        image_file = image_client.get(emoji_path)
 
-    """Creating a new emoji"""
-    image_file = image_client.get(emoji_path)
-    return destination_client.add_emoji(image_file, emoji_name)
+        return destination_client.add_emoji(image_file, destination_emoji_name)
+

--- a/emoji/slack_emoji_client.py
+++ b/emoji/slack_emoji_client.py
@@ -7,10 +7,11 @@ class SlackEmojiClient:
     def __init__(self, token):
         self.client = slack.WebClient(token=token)
 
-    def add_emoji(self, filepath, name):
+    def add_emoji(self, image_file, name):
+        """ `image_file` can be a local path to a file or a sublcass of `IOBase`. """
         return self.client.api_call(
             "emoji.add",
-            files={"image": filepath},
+            files={"image": image_file},
             data={"name": name, "mode": "data"}
         )
 


### PR DESCRIPTION
If we ask to transfer `'pelican'` and the destination already has their own resident `'pelican'`, this will allow us to have `'{prefix}-pelican'`.  Made the prefix injectable so we can let a user more easily specify a different prefix (let alone specify a different strategy).

Another approach here would be to catch this error:

```py
slack.errors.SlackApiError: The request to the Slack API failed.
The server responded with: {'ok': False, 'error': 'error_name_taken'}
```

but that feels a bit more defensive.