### PR TITLE
🙊 direct users to correct api keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ A way to move emoji from one Slack instance to another
 - Add appropriate environment variables.  You're going to want the following:
   | Key  | Description |
   | ------------- | ------------- |
-  | SOURCE_SLACK_API_KEY  | A personal API key generated from [Slack's legacy tokens documentation](https://api.slack.com/custom-integrations/legacy-tokens) for the Slack instance from which you would like to export emoji |
-  | DESTINATION_SLACK_API_KEY  | A personal API key generated from [Slack's legacy tokens documentation](https://api.slack.com/custom-integrations/legacy-tokens) for the Slack instance to which you would like to import emoji |
+  | SOURCE_SLACK_API_KEY  | A personal API key that can be found under `window.TS.boot_data.api_token` while inspecting the "customize slack" webpage of the source slack instance.  It should start with `xoxs-*`. |
+  | DESTINATION_SLACK_API_KEY  | A personal API key that can be found under `window.TS.boot_data.api_token` while inspecting the "customize slack" webpage of the source slack instance.  It should start with `xoxs-*`. |
 
 
 - Install the packages via `pip3`:


### PR DESCRIPTION
xoxs are required for uploading emoji, may as well use them everywhere.  There's no official documentation for using these ones, all they've got is https://api.slack.com/docs/token-types