### PR TITLE
🖼↔🖼 compare image hashes to prevent duplicate images

### DIFF
--- a/emoji/__init__.py
+++ b/emoji/__init__.py
@@ -3,6 +3,5 @@ import sys
 import slack
 from .slack_emoji_client import SlackEmojiClient
 
-
 def emoji_client(token):
     return SlackEmojiClient(token)

--- a/emoji/image_client.py
+++ b/emoji/image_client.py
@@ -1,6 +1,0 @@
-import requests
-from io import BytesIO
-
-def get(url):
-    response = requests.get(url)
-    return BytesIO(response.content)

--- a/image/image_client.py
+++ b/image/image_client.py
@@ -1,0 +1,11 @@
+import hashlib
+import requests
+from io import BytesIO
+
+def get(url):
+    response = requests.get(url)
+    return BytesIO(response.content)
+
+def hexdigest(image_binary):
+    """ accepts a BytesIO representation of an image (e.g., from `image_client.get()`) """
+    return hashlib.md5(image_binary.getvalue()).hexdigest()


### PR DESCRIPTION
this is a naïve approach because JPEG are lossy, but a fine first step.  I tried this with chrisgrin and the images were exactly the same despite being jpg.  In general if you wanted to try it you'd just do

```sh
python application.py $EMOJI_NAME
python application.py $EMOJI_NAME
```

And the second invocation would indicate that the emoji already exists.   Also added some logging but it's not perfect logging.