### PR TITLE
consider aliases when finding identical images

### DIFF
--- a/emoji/emoji_transfer_service.py
+++ b/emoji/emoji_transfer_service.py
@@ -52,7 +52,9 @@ def transfer(source_dict, destination_client, source_emoji_name):
         print("No existing image detected.  Adding new emoji '{}'.".format(name_of_source_emoji_in_destination))
         return destination_client.add_emoji(source_emoji_image, name_of_source_emoji_in_destination)
     else:
-        if destination_emoji_name_having_identical_image == source_emoji_name:
+        names_for_identical_image = destination_client.aliases_for_emoji_name().get(destination_emoji_name_having_identical_image)
+
+        if source_emoji_name in names_for_identical_image:
             print("source emoji '{}' already exists in the destination with this image and name.  Taking no action.".format(source_emoji_name))
             return None
         else:

--- a/emoji/slack_emoji_client.py
+++ b/emoji/slack_emoji_client.py
@@ -9,6 +9,7 @@ class SlackEmojiClient:
         self.client = slack.WebClient(token=token)
         self._emoji_dict = None
         self._hashes_for_emoji_images = None
+        self._aliases_for_emoji_name = None
 
     def add_emoji(self, image_file, name):
         """ `image_file` can be a local path to a file or a sublcass of `IOBase`. """
@@ -47,3 +48,20 @@ class SlackEmojiClient:
                     self._hashes_for_emoji_images[digest] = name
 
         return self._hashes_for_emoji_images
+
+    def aliases_for_emoji_name(self):
+        if self._aliases_for_emoji_name is None:
+            self._aliases_for_emoji_name = {}
+
+            for name, value in self.emoji_dict().items():
+                if value.startswith("alias:"):
+                    key = value.replace("alias:", "")
+                else:
+                    key = name
+
+                if self._aliases_for_emoji_name.get(key) is None:
+                    self._aliases_for_emoji_name[key] = set()
+
+                self._aliases_for_emoji_name[key].add(name)
+
+        return self._aliases_for_emoji_name


### PR DESCRIPTION
If I had an emoji `'original'` and an alias `'alias_of_original'`, and transfer an image named `'alias_of_original'` that matches this image, the `transfer_emoji()` function would only check whether the new name (`'alias_of_original'`) matched `'original'`, and try to add an alias if not.  

Because 'alias_of_original' was taken, it would add 'prefix-alias_of_original'.  This logic checks all aliases of the matching image before deciding to add a new alias.  One way this will break still:

```py
{
  'original': 'http://imgur.com/123',
  'effectively_original': 'http://imgur.com/123',
}
```

If I try to add `'effectively_original'` as a name with this same image, it will end up as `prefix-effectively_original` because the image-hash dictionary does not use sets.  We could try to work on this part if we decide it's worth it.