### PR TITLE
🏗 maintain in-memory representations of slack data

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,17 +34,17 @@ A way to move emoji from one Slack instance to another
 ## Testing in a python console
 #### Slack Emoji Client
 ```python
-from emoji import emoji_client
-client = emoji_client(<api_token>)
+from emoji import emoji_service
+service = emoji_service(<api_token>)
 ```
 
 #### Emoji Transfer Service (for transferring emoji)
 ```python
-from emoji import transfer_service, emoji_client
+from emoji import emoji_transfer_service, emoji_service
 
-source_client = emoji_client(<source_api_token>)
-destination_client = emoji_client(<destination_api_token>)
+source_dict = emoji_service(<source_api_token>).emoji_dict.emoji_dict # don't ask.
+destination_service = emoji_service(<destination_api_token>)
 emoji_name = "my-emoji"
 
-transfer_service.transfer(source_client, destination_client, emoji_name)
+emoji_transfer_service.transfer(source_dict, destination_service, emoji_name)
 ```

--- a/README.md
+++ b/README.md
@@ -40,11 +40,11 @@ client = emoji_client(<api_token>)
 
 #### Emoji Transfer Service (for transferring emoji)
 ```python
-from emoji import emoji_transfer_service, emoji_client
+from emoji import transfer_service, emoji_client
 
 source_client = emoji_client(<source_api_token>)
 destination_client = emoji_client(<destination_api_token>)
 emoji_name = "my-emoji"
 
-emoji_transfer_service.transfer(source_client, destination_client, emoji_name)
+transfer_service.transfer(source_client, destination_client, emoji_name)
 ```

--- a/app.py
+++ b/app.py
@@ -1,5 +1,5 @@
 from flask import Flask, jsonify, request
-from emoji import emoji_client, emoji_transfer_service
+from emoji import emoji_service, emoji_transfer_service
 import util.tokens as tokens
 import os
 import sys
@@ -17,9 +17,9 @@ def get_emoji_list():
         source_token = tokens.token_from_header_or_env(
             request.headers.get(tokens.SOURCE_AUTHORIZATION_HEADER, os.environ.get(tokens.SOURCE_ENV_VARIABLE))
         )
-        source_client = emoji_client(source_token)
+        source_service = emoji_service(source_token)
 
-        source_dict = source_client.emoji_dict()
+        source_dict = source_service.emoji_dict.emoji_dict # don't ask.
 
         # map alias values to URL values or None
         names_and_urls = {}
@@ -44,10 +44,10 @@ def transfer_emoji():
         request.headers.get(tokens.DESTINATION_AUTHORIZATION_HEADER, os.environ.get(tokens.DESTINATION_ENV_VARIABLE))
     )
 
-    source_dict = emoji_client(source_token).emoji_dict()
-    destination_client = emoji_client(destination_token)
+    source_dict = emoji_service(source_token).emoji_dict
+    destination_service = emoji_service(destination_token)
 
-    emoji_transfer_service.transfer(source_dict, destination_client, emoji_name)
+    emoji_transfer_service.transfer(source_dict, destination_service, emoji_name)
 
     return json.dumps({ 'success': True }), 200, { 'Content-Type': 'application/json' }
 

--- a/application.py
+++ b/application.py
@@ -3,11 +3,9 @@ import os
 import sys
 from util.tokens import SOURCE_ENV_VARIABLE, DESTINATION_ENV_VARIABLE
 
-from emoji import transfer_service, emoji_client
+from emoji import emoji_transfer_service, emoji_service
 
-source_client = emoji_client(os.environ[SOURCE_ENV_VARIABLE])
-destination_client = emoji_client(os.environ[DESTINATION_ENV_VARIABLE])
-# source_dict = json.load(open("results.json"))
-# destination_dict = destination_client.emoji_dict()
+source_service = emoji_service(os.environ[SOURCE_ENV_VARIABLE])
+destination_service = emoji_service(os.environ[DESTINATION_ENV_VARIABLE])
 
-transfer_service.transfer(source_client.emoji_dict(), destination_client, sys.argv[1])
+emoji_transfer_service.transfer(source_service.emoji_dict.emoji_dict, destination_service, sys.argv[1])

--- a/application.py
+++ b/application.py
@@ -3,11 +3,11 @@ import os
 import sys
 from util.tokens import SOURCE_ENV_VARIABLE, DESTINATION_ENV_VARIABLE
 
-from emoji import emoji_transfer_service, emoji_client
+from emoji import transfer_service, emoji_client
 
 source_client = emoji_client(os.environ[SOURCE_ENV_VARIABLE])
 destination_client = emoji_client(os.environ[DESTINATION_ENV_VARIABLE])
 # source_dict = json.load(open("results.json"))
 # destination_dict = destination_client.emoji_dict()
 
-emoji_transfer_service.transfer(source_client.emoji_dict(), destination_client, sys.argv[1])
+transfer_service.transfer(source_client.emoji_dict(), destination_client, sys.argv[1])

--- a/emoji/__init__.py
+++ b/emoji/__init__.py
@@ -1,7 +1,7 @@
 import os
 import sys
 import slack
-from .slack_emoji_client import SlackEmojiClient
+from .emoji_service import EmojiService
 
-def emoji_client(token):
-    return SlackEmojiClient(token)
+def emoji_service(token):
+    return EmojiService(token)

--- a/emoji/dicts/alias_dict.py
+++ b/emoji/dicts/alias_dict.py
@@ -1,0 +1,23 @@
+class AliasDict():
+    def __init__(self, emoji_dict):
+        self.aliases = {}
+
+        for name, value in emoji_dict.items():
+            if value.startswith("alias:"):
+                key = value.replace("alias:", "")
+            else:
+                key = name
+
+            self.update(name, key)
+
+    # TODO: make sure this is correct in the context of the transfer service.
+    def update(self, emoji_name, aliased_from):
+        if self.aliases.get(aliased_from) is None:
+            self.aliases[aliased_from] = set({ emoji_name, aliased_from })
+        else:
+            self.aliases[aliased_from].add(emoji_name)
+
+        return self.aliases
+
+    def get(self, key, default = None):
+        return self.aliases.get(key, default)

--- a/emoji/dicts/emoji_dict.py
+++ b/emoji/dicts/emoji_dict.py
@@ -1,0 +1,46 @@
+from .alias_dict import AliasDict
+from .image_hash_dict import ImageHashDict
+
+class EmojiDict:
+    def __init__(self, emoji_dict):
+        self.emoji_dict = emoji_dict
+        self._image_hash_dict = None
+        self._alias_dict = None
+
+    def get(self, key, default = None):
+        return self.emoji_dict.get(key, default)
+
+    def get_emoji(self, key, default = None):
+        return self.get(key, default)
+
+    def get_aliases(self, key, default = set()):
+        return self.alias_dict().get(key, default)
+
+    def get_emoji_name_for_image(self, image):
+        return self.image_hash_dict().get_for_image(image)
+
+    def add_alias(self, emoji_name, aliased_from):
+        self.emoji_dict.update(emoji_name = aliased_from)
+        self.alias_dict().update(emoji_name, aliased_from)
+
+        return self.emoji_dict
+
+    def add_emoji(self, emoji_name, image_url, image_file):
+        self.emoji_dict.update(emoji_name = image_url)
+        self.alias_dict().update(emoji_name, emoji_name)
+        self.image_hash_dict().update(emoji_name, image_file=image_file)
+
+        return self.emoji_dict
+
+    def alias_dict(self):
+        if self._alias_dict is None:
+            self._alias_dict = AliasDict(self.emoji_dict)
+
+        return self._alias_dict
+
+    def image_hash_dict(self):
+        """ crucial to lazy-load because initialization makes many API calls. """
+        if self._image_hash_dict is None:
+            self._image_hash_dict = ImageHashDict(self.emoji_dict)
+
+        return self._image_hash_dict

--- a/emoji/dicts/image_hash_dict.py
+++ b/emoji/dicts/image_hash_dict.py
@@ -1,0 +1,23 @@
+from image import image_client
+
+class ImageHashDict:
+    def __init__(self, emoji_dict):
+        self.image_hashes = {}
+
+        destination_emoji_with_urls = { name: val for name, val in emoji_dict.items() if not val.startswith("alias:") }
+
+        for name, url in destination_emoji_with_urls.items():
+            self.update(name, url)
+
+    def update(self, emoji_name, image_url = None, image_file = None):
+        digest = image_client.hexdigest(image = image_file, url = image_url)
+
+        if not self.image_hashes.get(digest):
+            self.image_hashes[digest] = emoji_name
+
+    def get_for_image(self, image):
+        digest = image_client.hexdigest(image = image)
+        return self.get(digest)
+
+    def get(self, key, default = None):
+        return self.image_hashes.get(key, default)

--- a/emoji/emoji_service.py
+++ b/emoji/emoji_service.py
@@ -1,0 +1,20 @@
+from .slack_emoji_client import SlackEmojiClient
+from .dicts.emoji_dict import EmojiDict
+
+class EmojiService():
+    def __init__(self, token):
+        self.client = SlackEmojiClient(token = token)
+        self.emoji_dict = EmojiDict(self.client.emoji_list().data['emoji'])
+
+    def add_emoji(self, name, image_file, image_url):
+        """ unfortunately the repsonse from the client is only { 'ok': True } so we don't have the actual URL """
+        self.client.add_emoji(image_file, name)
+        # breakpoint()
+        self.emoji_dict.add_emoji(name, image_url=image_url, image_file=image_file)
+
+    def add_alias(self, emoji_name, aliased_from):
+        self.client.add_alias(emoji_name, aliased_from)
+        self.emoji_dict.add_alias(emoji_name, aliased_from)
+
+    def destination_emoji_name_having_identical_image(self, emoji_name):
+        return self.emoji_dict.alias_dict().get(emoji_name)

--- a/emoji/slack_emoji_client.py
+++ b/emoji/slack_emoji_client.py
@@ -1,4 +1,5 @@
 import os
+from copy import copy
 import sys
 import slack
 from image import image_client
@@ -7,15 +8,12 @@ from image import image_client
 class SlackEmojiClient:
     def __init__(self, token):
         self.client = slack.WebClient(token=token)
-        self._emoji_dict = None
-        self._hashes_for_emoji_images = None
-        self._aliases_for_emoji_name = None
 
     def add_emoji(self, image_file, name):
         """ `image_file` can be a local path to a file or a sublcass of `IOBase`. """
         return self.client.api_call(
             "emoji.add",
-            files={"image": image_file},
+            files={"image": copy(image_file)},
             data={"name": name, "mode": "data"}
         )
 
@@ -29,39 +27,6 @@ class SlackEmojiClient:
     def remove_emoji(self, name):
         return self.client.api_call("emoji.remove", data={"name": name, "mode": "data"})
 
-    def emoji_dict(self):
-        if self._emoji_dict is None:
-            self._emoji_dict = self.client.emoji_list().data['emoji']
+    def emoji_list(self):
+        return self.client.emoji_list()
 
-        return self._emoji_dict
-
-    def hashes_for_emoji_images(self):
-        if self._hashes_for_emoji_images is None:
-            self._hashes_for_emoji_images = {}
-            destination_emoji_with_urls = { name: val for name, val in self.emoji_dict().items() if not val.startswith("alias:") }
-
-            for name, url in destination_emoji_with_urls.items():
-                image = image_client.get(url)
-                digest = image_client.hexdigest(image)
-
-                if not self._hashes_for_emoji_images.get(digest):
-                    self._hashes_for_emoji_images[digest] = name
-
-        return self._hashes_for_emoji_images
-
-    def aliases_for_emoji_name(self):
-        if self._aliases_for_emoji_name is None:
-            self._aliases_for_emoji_name = {}
-
-            for name, value in self.emoji_dict().items():
-                if value.startswith("alias:"):
-                    key = value.replace("alias:", "")
-                else:
-                    key = name
-
-                if self._aliases_for_emoji_name.get(key) is None:
-                    self._aliases_for_emoji_name[key] = set()
-
-                self._aliases_for_emoji_name[key].add(name)
-
-        return self._aliases_for_emoji_name

--- a/image/image_client.py
+++ b/image/image_client.py
@@ -6,6 +6,12 @@ def get(url):
     response = requests.get(url)
     return BytesIO(response.content)
 
-def hexdigest(image_binary):
+def hexdigest(image = None, url = None):
+    if not bool(image) ^ bool(url):
+        raise('must include precisely one of `image` or `url`')
+
+    if image is None:
+        image = get(url)
+
     """ accepts a BytesIO representation of an image (e.g., from `image_client.get()`) """
-    return hashlib.md5(image_binary.getvalue()).hexdigest()
+    return hashlib.md5(image.getvalue()).hexdigest()


### PR DESCRIPTION
We maintain our own Dicts (the EmojiDict should probably be EmojiStore) so that we don't have to ask the destination for its emoji data every time we add a new emoji.  this will let us add multiple emoji in the same request while only making the API calls for images once.

Verified via postman that the get/post endpoints still work for many cases.