### PR TITLE
📝 add instructions for installing CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ You're going to want the following environment variables set in your virtual env
   | SOURCE_SLACK_API_TOKEN  | A personal API key that can be found under `window.TS.boot_data.api_token` while inspecting the "customize slack" webpage of the source slack instance.  It should start with `xoxs-*`. |
   | DESTINATION_SLACK_API_TOKEN  | A personal API key that can be found under `window.TS.boot_data.api_token` while inspecting the "customize slack" webpage of the destination slack instance.  It should start with `xoxs-*`. |
 
+Additionally, you'll need to enable the CLI scripts by "installing" the repo itself:
+
+```sh
+(env) $ pip install --editable .
+```
+
+For more about this step, read the [Click documentation](https://click.palletsprojects.com/en/5.x/setuptools/#setuptools-integration).
+
 ### List of names
 You can transfer a list of emoji names, e.g. `transfer emoji_1 emoji_2 emoji_3`
 


### PR DESCRIPTION
we need this to be able to run `transfer` from the CLI.