### PR TITLE
♻️improve retry utility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/delete_emoji.py
+++ b/delete_emoji.py
@@ -1,23 +1,42 @@
-# import json
 import os
 import sys
+import time
+from util.status_codes import TOO_MANY_REQUESTS
 from util.tokens import DESTINATION_ENV_VARIABLE
-
+from slack.errors import SlackApiError
 from emoji.slack_emoji_client import SlackEmojiClient
 
-client = SlackEmojiClient(os.environ[DESTINATION_ENV_VARIABLE])
+failed_emoji = []
+try:
+    client = SlackEmojiClient(os.environ[DESTINATION_ENV_VARIABLE])
 
-emoji = client.emoji_list().data['emoji']
-emoji_name = set(sys.argv[1:])
+    emoji = client.emoji_list().data['emoji']
+    emoji_name = set(sys.argv[1:])
 
-if len(emoji_name) > 0:
-    emoji_to_delete = { k: v for k, v in emoji.items() if k in emoji_name }
-else:
-    emoji_to_delete = emoji
+    if len(emoji_name) > 0:
+        emoji_to_delete = { k: v for k, v in emoji.items() if k in emoji_name }
+    else:
+        emoji_to_delete = emoji
 
-for name, url in emoji_to_delete.items():
-    try:
-        client.remove_emoji(name)
-        print("deleted {}".format(name))
-    except:
-        print("You don't have permission to delete {}".format(name))
+    for name, url in sorted(emoji_to_delete.items()):
+        try:
+            client.remove_emoji(name)
+            print("deleted {}".format(name))
+            time.sleep(1)
+        except SlackApiError as error:
+            print("failed on {}".format(name))
+            failed_emoji.append(name)
+            if error.response.status_code == TOO_MANY_REQUESTS:
+                time_to_sleep = 60
+                print("Rate limit reached. Sleeping {} seconds".format(time_to_sleep))
+                time.sleep(time_to_sleep)
+            else:
+                print("Received SlackApiError: {}".format(error.response.data.get('error')))
+        except Exception as e:
+            failed_emoji.append(name)
+            print("Unknown exception encountered while attempting to delete {}.".format(name))
+finally:
+    if len(failed_emoji) > 0:
+        print("😿 deletion failed for:\n{}\n\n\n\n\n\n\n".format(
+            "\n".join(sorted(failed_emoji))
+        ))

--- a/emoji/emoji_service.py
+++ b/emoji/emoji_service.py
@@ -9,12 +9,11 @@ class EmojiService():
     def add_emoji(self, name, image_file, image_url):
         """ unfortunately the repsonse from the client is only { 'ok': True } so we don't have the actual URL """
         self.client.add_emoji(image_file, name)
-        # breakpoint()
-        self.emoji_dict.add_emoji(name, image_url=image_url, image_file=image_file)
+        return self.emoji_dict.add_emoji(name, image_url=image_url, image_file=image_file)
 
     def add_alias(self, emoji_name, aliased_from):
         self.client.add_alias(emoji_name, aliased_from)
-        self.emoji_dict.add_alias(emoji_name, aliased_from)
+        return self.emoji_dict.add_alias(emoji_name, aliased_from)
 
     def destination_emoji_name_having_identical_image(self, emoji_name):
         return self.emoji_dict.alias_dict().get(emoji_name)

--- a/emoji/emoji_transfer_service.py
+++ b/emoji/emoji_transfer_service.py
@@ -34,18 +34,26 @@ def collision_free_name(destination_dict, source_emoji_name, prefix="cav"):
     return destination_name
 
 def transfer(source_dict, destination_service, source_emoji_name):
+    """
+    Moves an emoji with `source_emoji_name` from a source client's dictionary to a destionation client.
+
+    `transfer` will do nothing if the emoji exists with the same name and image in the destination.
+    `transfer` will alias an destination emoji if the image exists with a different name.
+    `transfer` will prefix the source emoji name with 'cav-' if the name exists for a different image.
+    """
+
     print("Transferring '{}'".format(source_emoji_name))
 
     try:
         emoji_image_url = url_even_if_alias(source_dict, source_emoji_name)
     except EmojiNotFoundError:
-        print("Image file not found for emoji '{}'".format(source_emoji_name))
+        print("🔍 Image file not found for emoji '{}'".format(source_emoji_name))
         return
 
     if emoji_image_url is None:
         # Making an alias for a standard emoji
         standard_emoji_name = source_dict.get(source_emoji_name).replace("alias:", "")
-        print("'{}' aliases standard emoji '{}' detected.  Creating alias.".format(source_emoji_name, standard_emoji_name))
+        print("✅ '{}' aliases standard emoji '{}' detected.  Creating alias.".format(source_emoji_name, standard_emoji_name))
         return destination_service.add_alias(source_emoji_name, standard_emoji_name)
 
     # Creating a new emoji
@@ -57,7 +65,7 @@ def transfer(source_dict, destination_service, source_emoji_name):
 
     if destination_emoji_name_having_identical_image is None:
         name_of_source_emoji_in_destination = collision_free_name(destination_dict, source_emoji_name)
-        print("No existing image detected.  Adding new emoji '{}'.".format(name_of_source_emoji_in_destination))
+        print("✅ No existing image detected.  Adding new emoji '{}'.".format(name_of_source_emoji_in_destination))
         return destination_service.add_emoji(
             name_of_source_emoji_in_destination,
             source_emoji_image,
@@ -66,16 +74,14 @@ def transfer(source_dict, destination_service, source_emoji_name):
         names_for_identical_image = destination_service.emoji_dict.get_aliases(destination_emoji_name_having_identical_image)
 
         if source_emoji_name in names_for_identical_image:
-            print("source emoji '{}' already exists in the destination with this image and name.  Taking no action.".format(source_emoji_name))
+            print("🙈 source emoji '{}' already exists in the destination with this image and name.  Taking no action.".format(source_emoji_name))
             return None
         else:
             name_of_source_emoji_in_destination = collision_free_name(destination_dict, source_emoji_name)
-            print("source emoji '{source_emoji_name}' exists as destination emoji '{identical_destination_emoji_name}' with the same image.  Creating alias '{aliased_name}'.".format(
+            print("✅ source emoji '{source_emoji_name}' exists as destination emoji '{identical_destination_emoji_name}' with the same image.  Creating alias '{aliased_name}'.".format(
                 source_emoji_name=source_emoji_name,
                 identical_destination_emoji_name=destination_emoji_name_having_identical_image,
                 aliased_name=name_of_source_emoji_in_destination
             ))
 
             return destination_service.add_alias(name_of_source_emoji_in_destination, destination_emoji_name_having_identical_image)
-
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ MarkupSafe==1.1.1
 multidict==4.5.2
 requests==2.22.0
 six==1.12.0
-slackclient==2.1.0
+slackclient==2.2.1
 urllib3==1.25.3
 Werkzeug==0.15.5
 yarl==1.3.0

--- a/scripts/transfer_cli.py
+++ b/scripts/transfer_cli.py
@@ -3,50 +3,86 @@ import csv
 import os
 import re
 import time
-
+from slack.errors import SlackApiError
 from emoji import emoji_transfer_service, emoji_service, find_all_emoji_by_name
+from util.iterable import each_slice
+from util.status_codes import TOO_MANY_REQUESTS
 from util.tokens import SOURCE_ENV_VARIABLE, DESTINATION_ENV_VARIABLE
-
 
 class InputError(Exception):
     pass
 
 
-CHUNK_SIZE = os.environ.get('CHUNK_SIZE', 40)
 SLEEP_SECONDS = os.environ.get('SLEEP_SECONDS', 60)
-
+SLICE_SIZE = os.environ.get('SLICE_SIZE', 30) # empirically, the API accepts 30 calls per minute.
 
 @click.command()
 @click.option('--source', default=None, help='A csv filename from which to import emoji')
 @click.argument('emoji_names', nargs=-1)
 def import_emoji(emoji_names, source):
+    """
+    Transfers emoji from one slack to another via EmojiTransferService.
+
+    Input argument (CLI) can be a series of names or a path to a CSV file (via `--source` option).
+
+    Source and destination are configured via environment variables defined by the *_ENV_VARIABLE
+    consants in util.tokens.
+
+    Slicing is done to pre-emptively avoid rate-limiting, but rate-limiting is also handled.
+    """
     if not bool(source) ^ bool(emoji_names):
-        raise InputError("You must either provide a list emoji_names or provide a CSV file via the --csv option")
+        raise InputError("You must either provide a list emoji_names or provide a CSV file via the --source option")
 
     source_dict = emoji_service(os.environ.get(SOURCE_ENV_VARIABLE)).emoji_dict.emoji_dict
     destination_service = emoji_service(os.environ.get(DESTINATION_ENV_VARIABLE))
     if bool(source):
         emoji_names = _emoji_from_csv(source)
 
-    emoji_names_to_be_transferred = find_all_emoji_by_name(emoji_names, source_dict)
+    emoji_names_to_be_transferred = sorted(find_all_emoji_by_name(emoji_names, source_dict))
 
-    for emoji_names in each_slice(emoji_names_to_be_transferred):
-        for emoji_name in emoji_names:
-            try:
-                emoji_transfer_service.transfer(
-                    source_dict,
-                    destination_service,
-                    emoji_name
-                )
-            except:
-                print("Unable to add {} - probably a standard emoji".format(emoji_name))
+    failed_emoji = []
+    try:
+        for emoji_name_slice in each_slice(emoji_names_to_be_transferred, SLICE_SIZE):
+            uploads_for_slice = 0 # avoids proactive waiting in idempotency.
+            for emoji_name in emoji_name_slice:
+                try:
+                    result = emoji_transfer_service.transfer(
+                        source_dict,
+                        destination_service,
+                        emoji_name
+                    )
+                    if result is not None:
+                        uploads_for_slice += 1
+                except SlackApiError as api_error:
+                    failed_emoji.append(emoji_name)
+                    print("SlackApiError {} encountered for emoji {}.".format(
+                        api_error.response.data.get('error', '(unknown)'),
+                        emoji_name
+                    ))
+                    # Too Many Requests should come with a 'Retry-After' header per the documentation.
+                    if api_error.response.status_code == TOO_MANY_REQUESTS:
+                        # The response includes a Retry-After header but in practice it doens't allow
+                        # many more requests after this value before failing with another 429.
+                        # Instead of eating that many failures, we'll sleep for 60 seconds, which in
+                        # practice allows another 30 requests before failing agianag
+                        print("🛑 Rate limit reached.  Sleeping for {} seconds".format(SLEEP_SECONDS))
+                        time.sleep(SLEEP_SECONDS)
+                except Exception as e:
+                    failed_emoji.append(emoji_name)
+                    print("Unknown exception {} for {}.".format(e, emoji_name))
 
+            if uploads_for_slice > 0:
+                print("😴 Proactive stalling.  Sleeping for {} seconds".format(SLEEP_SECONDS))
+                time.sleep(SLEEP_SECONDS)
+            else:
+                print("No uploads for slice.  Onward and Upward 📈.")
 
-        if len(emoji_names) > 1:
-            print("SLEEPING FOR {} SECONDS TO AVOID RATE LIMITING".format(SLEEP_SECONDS))
-            time.sleep(SLEEP_SECONDS)
-
-    print("🦙 Transfer complete! 🦙")
+        print("🎉 Transfer complete! 🎉")
+    finally:
+        if len(failed_emoji) > 0:
+            print("😿 failed to transfer the following:\n{}\n\n\n\n\n\n\n".format(
+                "\n".join(failed_emoji)
+            ))
 
 def _emoji_from_csv(source):
     emoji_names = set()
@@ -56,25 +92,3 @@ def _emoji_from_csv(source):
             emoji_names.add(row['emoji name'])
 
     return emoji_names
-
-
-def each_slice(iterable):
-    """ Chunks the iterable into size elements at a time, each yielded as a list.
-
-    Example:
-      for chunk in each_slice(2, [1,2,3,4,5]):
-          print(chunk)
-
-      # output:
-      [1, 2]
-      [3, 4]
-      [5]
-    """
-    current_slice = []
-    for item in iterable:
-        current_slice.append(item)
-        if len(current_slice) >= CHUNK_SIZE:
-            yield current_slice
-            current_slice = []
-    if current_slice:
-        yield current_slice

--- a/util/iterable.py
+++ b/util/iterable.py
@@ -1,0 +1,22 @@
+"""Utilities for iterables."""
+def each_slice(iterable, slice_size):
+    """
+    Chunks the iterable into size elements at a time, each yielded as a list.
+
+    Example:
+      for chunk in each_slice([1,2,3,4,5], slice_size=2):
+          print(chunk)
+
+      # output:
+      [1, 2]
+      [3, 4]
+      [5]
+    """
+    current_slice = []
+    for item in iterable:
+        current_slice.append(item)
+        if len(current_slice) >= slice_size:
+            yield current_slice
+            current_slice = []
+    if current_slice:
+        yield current_slice

--- a/util/status_codes.py
+++ b/util/status_codes.py
@@ -1,0 +1,2 @@
+"""HTTP status codes by name."""
+TOO_MANY_REQUESTS = 429


### PR DESCRIPTION
Didn't have a plan going into this so wasn't able to break it into logical commits.

- the new slack version gives access to the whole response, so we can intentionally stop on 429s, which per their documentation are used when we hit their rate limit.

- Adjusted the default chunk size in transfer_cli.py to 30 based on anecdotal counting after implementing the ex post facto sleeping based on 429 responses.

- Sort input to improve idempotency: re-running on a CSV will always import the emoji alphabetically.

- Count whether a slice has hit the API to improve utility of re-running script.  If the service does not hit the API for any emoji in a slice (because it can tell whether it exists with the same name), don't sleep after the slice.

- add finally blocks to log which emoji failed.  This is less useful now that re-trying is easier, but useful to verify that the retries run as expected.

### 📸
<img width="1280" alt="Screen Shot 2019-11-20 at 11 48 52 PM" src="https://user-images.githubusercontent.com/12285859/69317764-859df680-0bf0-11ea-8b64-3429d033c523.png">
<img width="1280" alt="Screen Shot 2019-11-20 at 11 49 19 PM" src="https://user-images.githubusercontent.com/12285859/69317765-859df680-0bf0-11ea-9e53-e276a577bba5.png">
